### PR TITLE
use relative recipe names

### DIFF
--- a/layers/tedge.toml
+++ b/layers/tedge.toml
@@ -13,11 +13,11 @@ recipes = [
     "rugpi-extra/zsh",
 
     # thin-edge.io recipes
-    "tedge-rugpi-core/persist-overlay",
-    "tedge-rugpi-core/tedge-firmware-update",
-    "tedge-rugpi-core/set-wifi",
-    "tedge-rugpi-core/mosquitto",
-    "tedge-rugpi-core/sbom",
+    "persist-overlay",
+    "tedge-firmware-update",
+    "set-wifi",
+    "mosquitto",
+    "sbom",
 ]
 
 [parameters."core/apt-cleanup"]

--- a/rugpi-repository.toml
+++ b/rugpi-repository.toml
@@ -1,2 +1,5 @@
 name = "tedge-rugpi-core"
 description = "thin-edge.io recipes, collections, and layers for Rugpi."
+
+[repositories]
+rugpi-extra = { git = "https://github.com/silitics/rugpi-extra.git" }


### PR DESCRIPTION
Recipe names in layers are now always resolved relative to the repository the layers are defined in. I think, that this makes more sense from a composition perspective.