### PR TITLE
feat!(sbom): write sbom to project root directory

### DIFF
--- a/recipes/sbom/steps/00-install.sh
+++ b/recipes/sbom/steps/00-install.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
 set -e
 echo "Creating Software Bill Of Materials"
-if [ -n "$RECIPE_DIR" ]; then
-    dpkg --list > "$RECIPE_DIR/debian-packages.list"
+
+ENV_FILE="$RUGPI_PROJECT_DIR/.env"
+
+if [ -f "$ENV_FILE" ]; then
+    echo "Loading .env file" >&2
+    # shellcheck disable=SC1090
+    . "$ENV_FILE"
+fi
+
+if [ -n "$RUGPI_PROJECT_DIR" ]; then
+    SBOM_FILENAME=${IMAGE_FULLNAME:-debian-packages.list}
+    dpkg --list > "$RUGPI_PROJECT_DIR/$SBOM_FILENAME"
 else
-    dpkg --list
+    dpkg --list >&2
 fi


### PR DESCRIPTION
Write the sbom to the base project directory, and allow the filename to be controlled via `IMAGE_FULLNAME` set in the `$RUGPI_PROJECT_DIR/.env` dotenv file