### PR TITLE
feat: add ssh recipe to add custom authorized keys via env variables

### DIFF
--- a/recipes/ssh/recipe.toml
+++ b/recipes/ssh/recipe.toml
@@ -1,0 +1,5 @@
+description = "ssh authorized keys using config or env variables SSH_KEYS_.*"
+dependencies = ["core/ssh"]
+
+[parameters]
+root_authorized_keys = { default = "" }

--- a/recipes/ssh/steps/00-install.sh
+++ b/recipes/ssh/steps/00-install.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+ENV_FILE="$RUGPI_PROJECT_DIR/.env"
+
+if [ -f "$ENV_FILE" ]; then
+    echo "Loading .env file" >&2
+    # shellcheck disable=SC1090
+    . "$ENV_FILE"
+fi
+
+add_ssh_key() {
+    key="$1"
+    echo "$key" >> /root/.ssh/authorized_keys
+}
+
+SSH_KEYS=$(env | grep -E '^SSH_KEYS_[0-9a-zA-Z_]+=' | cut -d= -f1)
+
+if [ -n "${RECIPE_PARAM_ROOT_AUTHORIZED_KEYS}" ] || [ -n "$SSH_KEYS" ]; then
+    mkdir -p /root/.ssh
+
+    if [ -n "${RECIPE_PARAM_ROOT_AUTHORIZED_KEYS}" ]; then
+        add_ssh_key "${RECIPE_PARAM_ROOT_AUTHORIZED_KEYS}"
+    fi
+
+    if [ -n "$SSH_KEYS" ]; then
+        # Add keys from any env variables which start with SSH_KEYS_[0-9a-zA-Z_]+
+        while read -r name; do
+            echo "Adding key from env $name" >&2
+            value=$(eval "echo \$$name")
+            add_ssh_key "$value"
+        done < <(echo "$SSH_KEYS")
+    fi
+
+    chmod -R 600 /root/.ssh
+    cat /root/.ssh/authorized_keys >&2
+fi


### PR DESCRIPTION
The `ssh` recipe can add ssh keys from env variables provided in a dotenv file `.env` (located at the project root directory).

**file: .env**

```
SSH_KEYS_example="ssh-rsa xxxxx"
SSH_KEYS_other="ssh-rsa bbbbb"
```