### PR TITLE
fix(ssh): export sourced dotenv file variables

### DIFF
--- a/recipes/ssh/steps/00-install.sh
+++ b/recipes/ssh/steps/00-install.sh
@@ -5,8 +5,11 @@ ENV_FILE="$RUGPI_PROJECT_DIR/.env"
 
 if [ -f "$ENV_FILE" ]; then
     echo "Loading .env file" >&2
+    # Export all variables included in the file so that env can read them as well
+    set -a
     # shellcheck disable=SC1090
     . "$ENV_FILE"
+    set +a
 fi
 
 add_ssh_key() {


### PR DESCRIPTION
Fix bug where the sourced dotenv file was not being exported and hence no ssh keys were being detected