### PR TITLE
Persist Docker

### DIFF
--- a/recipes/docker/files/docker.toml
+++ b/recipes/docker/files/docker.toml
@@ -1,0 +1,5 @@
+[[persist]]
+directory = "/etc/docker"
+
+[[persist]]
+directory = "/var/lib/docker"

--- a/recipes/docker/steps/00-install.sh
+++ b/recipes/docker/steps/00-install.sh
@@ -24,3 +24,6 @@ apt-get install -y --no-install-recommends \
     tedge-container-plugin
 
 usermod -aG docker tedge
+
+# Copy Docker persist file
+install -D -m 644 "${RECIPE_DIR}/files/docker.toml" -t /etc/rugpi/state


### PR DESCRIPTION
Persisting  docker directories 

/etc/docker 
/var/lib/docker 

Now Docker containers survive a firmware update