### PR TITLE
fix(wifi): remove rfkill software kill switches by default

### DIFF
--- a/recipes/thin-edge.io/steps/00-install.sh
+++ b/recipes/thin-edge.io/steps/00-install.sh
@@ -41,6 +41,20 @@ tedge config set c8y.enable.firmware_update "true"
 # Enable network manager by default
 systemctl enable NetworkManager || true
 
+# Remove software kill switches which would otherwise prevent the wifi from being enabled by default on rpi 3 and 4's
+# Related to https://github.com/thin-edge/tedge-rugpi-image/issues/69
+# On RaspberryPiOS the image disables the wifi by default on 5Ghz devices if the country code is not set
+# but since we are building generic images the wifi will be enabled by default.
+#
+# For background checkout the following links
+# * https://github.com/RPi-Distro/pi-gen/issues/414
+# * https://github.com/RPi-Distro/pi-gen/blob/master/stage2/02-net-tweaks/01-run.sh#L28
+if [ -d /var/lib/systemd/rfkill ]; then
+    echo "Enabling wifi on 5GHz enabled devices by default" >&2
+    echo 0 > "/var/lib/systemd/rfkill/platform-3f300000.mmcnr:wlan"
+    echo 0 > "/var/lib/systemd/rfkill/platform-fe300000.mmcnr:wlan"
+fi
+
 # Enable services by default to have sensible default settings once tedge is configured
 systemctl enable tedge-agent
 systemctl enable tedge-mapper-c8y


### PR DESCRIPTION
Raspberry Pi OS images activate a kill switch for rpi 3 and 4
which prevents the wifi from being active by default on these images.

Refs: https://github.com/thin-edge/tedge-rugpi-image/issues/69

For background checkout the following links:
* https://github.com/RPi-Distro/pi-gen/issues/414
* https://github.com/RPi-Distro/pi-gen/blob/master/stage2/02-net-tweaks/01-run.sh#L28