### PR TITLE
fix: check rugpi partition information with elevated rights

### DIFF
--- a/recipes/tedge-firmware-update/files/firmware-auto-rollback
+++ b/recipes/tedge-firmware-update/files/firmware-auto-rollback
@@ -1,7 +1,12 @@
 #!/bin/sh
 set -e
 
-RUGPI_INFO=$(rugpi-ctrl system info ||:)
+SUDO=""
+if command -V sudo >/dev/null 2>&1; then
+    SUDO="sudo"
+fi
+
+RUGPI_INFO=$($SUDO rugpi-ctrl system info ||:)
 HOT=$(echo "$RUGPI_INFO" | grep Hot | cut -d: -f2 | xargs)
 DEFAULT=$(echo "$RUGPI_INFO" | grep Default | cut -d: -f2 | xargs)
 

--- a/recipes/tedge-firmware-update/files/firmware-auto-rollback
+++ b/recipes/tedge-firmware-update/files/firmware-auto-rollback
@@ -5,7 +5,7 @@ RUGPI_INFO=$(rugpi-ctrl system info ||:)
 HOT=$(echo "$RUGPI_INFO" | grep Hot | cut -d: -f2 | xargs)
 DEFAULT=$(echo "$RUGPI_INFO" | grep Default | cut -d: -f2 | xargs)
 
-if [ "$HOT" = "$DEFAULT" ]; then
+if [ -n "$HOT" ] && [ -n "$DEFAULT" ] && [ "$HOT" = "$DEFAULT" ]; then
     echo "Already on default partition. Nothing to rollback to. hot=$HOT, default=$DEFAULT" >&2
     exit 0
 fi

--- a/recipes/tedge-firmware-update/files/rugpi_workflow.sh
+++ b/recipes/tedge-firmware-update/files/rugpi_workflow.sh
@@ -258,7 +258,7 @@ commit() {
     case "$EXIT_CODE" in
         0)
             # Check what the updated default partition is
-            DEFAULT=$(rugpi-ctrl system info | grep Default | cut -d: -f2 | tr '[:lower:]' '[:upper:]' | xargs)
+            DEFAULT=$($SUDO rugpi-ctrl system info | grep Default | cut -d: -f2 | tr '[:lower:]' '[:upper:]' | xargs)
 
             log "Commit successful. New default partition is $DEFAULT"
             # Save firmware meta information to file (for reading on startup during normal operation)

--- a/recipes/tedge-firmware-update/files/rugpi_workflow.sh
+++ b/recipes/tedge-firmware-update/files/rugpi_workflow.sh
@@ -227,6 +227,12 @@ restart() {
 verify() {
     log "Checking device health"
 
+    # Rollback just in case if the partitions could not be read, so we can't confirm which partition we are on
+    if [ -z "$HOT" ] || [ -z "$DEFAULT" ]; then
+        set_reason "Could not read partition information so rolling back to be safe. HOT=$HOT, DEFAULT=$DEFAULT"
+        exit "$REQUEST_RESTART"
+    fi
+
     if [ "$HOT" = "$DEFAULT" ]; then
         # Don't both to reboot if no partition swap occurred because we are already in the ok partition
         set_reason "Partition swap did not occur. Reasons could be, corrupt/non-bootable image, someone did a manual rollback or the machine was restarted manually before the health check was run"

--- a/recipes/tedge-firmware-update/files/rugpi_workflow.sh
+++ b/recipes/tedge-firmware-update/files/rugpi_workflow.sh
@@ -26,9 +26,10 @@ _WORKDIR=$(pwd)
 # Change to a directory which is readable otherwise rugpi-ctrl can have problems reading the mounts
 cd /tmp || cd /
 
-HOT=$(rugpi-ctrl system info | grep Hot | cut -d: -f2 | tr '[:lower:]' '[:upper:]' | xargs)
-DEFAULT=$(rugpi-ctrl system info | grep Default | cut -d: -f2 | tr '[:lower:]' '[:upper:]' | xargs)
-SPARE=$(rugpi-ctrl system info | grep Spare | cut -d: -f2 | tr '[:lower:]' '[:upper:]' | xargs)
+RUGPI_INFO=$($SUDO rugpi-ctrl system info ||:)
+HOT=$(echo "$RUGPI_INFO" | grep Hot | cut -d: -f2 | tr '[:lower:]' '[:upper:]' | xargs)
+DEFAULT=$(echo "$RUGPI_INFO" | grep Default | cut -d: -f2 | tr '[:lower:]' '[:upper:]' | xargs)
+SPARE=$(echo "$RUGPI_INFO" | grep Spare | cut -d: -f2 | tr '[:lower:]' '[:upper:]' | xargs)
 
 ACTION="$1"
 shift


### PR DESCRIPTION
In Rugpi >= 0.7, `rugpi-ctrl system info` now requires root privileges to check the partition information.

The following improvements were also made to handle cases where getting the current partition information fails (for unexpected reasons):

* The auto rollback service will rollback if it fails to get the partition information
* The verify state will fail and trigger a rollback if the partition information is empty
* Reduced number of calls to the `rugpi-ctrl system info` when initially reading the partition information