### PR TITLE
chore: remove usage of deprecated rugpi-ctrl stream option

### DIFF
--- a/recipes/tedge-firmware-update/files/rugpi_workflow.sh
+++ b/recipes/tedge-firmware-update/files/rugpi_workflow.sh
@@ -182,12 +182,12 @@ install() {
     case "$url" in
         http://*|https://*)
             log "Downloading and streaming image to rugpi"
-            wget -c -q -t 0 -O - "$url" | $SUDO rugpi-ctrl update install --stream --no-reboot -
+            wget -c -q -t 0 -O - "$url" | $SUDO rugpi-ctrl update install --no-reboot -
             ;;
         *)
             # It is a file
             log "Installing local image to rugpi"
-            $SUDO rugpi-ctrl update install --stream --no-reboot "$url"
+            $SUDO rugpi-ctrl update install --no-reboot "$url"
             ;;
     esac
     EXIT_CODE=$?


### PR DESCRIPTION
Remove usage of deprecated `--stream` in the firmware update workflow.

An example of the deprcation warning is shown below:

```
**Deprecation Warning:**
The option `--stream` has been deprecated and will be removed in future versions.
Streaming updates are the default now.
```