### PR TITLE
fix: update software-management log path

### DIFF
--- a/recipes/thin-edge.io/files/tedge-log-plugin.toml
+++ b/recipes/thin-edge.io/files/tedge-log-plugin.toml
@@ -1,6 +1,6 @@
 [[files]]
 type = "software-management"
-path = "/var/log/tedge/agent/software-*"
+path = "/var/log/tedge/agent/workflow-software_update*"
 
 [[files]]
 type = "firmware_update"


### PR DESCRIPTION
Updating the log path after it changed in thin-edge.io 1.3.0