### PR TITLE
feat!: add systemd-resolved to support mdns resolution on an OS level

### DIFF
--- a/recipes/defaults/recipe.toml
+++ b/recipes/defaults/recipe.toml
@@ -4,6 +4,7 @@ dependencies = [
     "rugpi-extra/zsh",
 
     "essentials",
+    "network",
     "persist-network-manager",
     "set-wifi",
     "sbom",

--- a/recipes/essentials/recipe.toml
+++ b/recipes/essentials/recipe.toml
@@ -5,6 +5,5 @@ dependencies = [
     "persist-overlay",
     "tedge-bootstrap",
     "tedge-firmware-update",
-    "avahi-daemon",
     "mosquitto",
 ]

--- a/recipes/network/files/NetworkManager.conf
+++ b/recipes/network/files/NetworkManager.conf
@@ -1,0 +1,9 @@
+[main]
+plugins=ifupdown,keyfile
+dns=systemd-resolved
+
+[ifupdown]
+managed=false
+
+[device]
+wifi.scan-rand-mac-address=no

--- a/recipes/network/files/dns-sd/sftp-ssh.dnssd
+++ b/recipes/network/files/dns-sd/sftp-ssh.dnssd
@@ -1,0 +1,4 @@
+[Service]
+Name=%H
+Type=_sftp-ssh._tcp
+Port=22

--- a/recipes/network/files/dns-sd/ssh.dnssd
+++ b/recipes/network/files/dns-sd/ssh.dnssd
@@ -1,0 +1,4 @@
+[Service]
+Name=%H
+Type=_ssh._tcp
+Port=22

--- a/recipes/network/files/dns-sd/tedge.dnssd
+++ b/recipes/network/files/dns-sd/tedge.dnssd
@@ -1,0 +1,5 @@
+[Service]
+Name=%H
+Type=_tedge._tcp
+Port=8883
+TxtText=fts_port=8000 c8y_proxy_port=8001 mqtt_port=8883

--- a/recipes/network/files/globals.conf
+++ b/recipes/network/files/globals.conf
@@ -1,0 +1,6 @@
+[connection]
+# 0 = off, 1 = resolver, 2 = resolver and responder
+connection.mdns=1
+
+# Disable LLMNR as it can conflict with mdns
+connection.llmnr=0

--- a/recipes/network/files/globals.conf
+++ b/recipes/network/files/globals.conf
@@ -1,6 +1,6 @@
 [connection]
 # 0 = off, 1 = resolver, 2 = resolver and responder
-connection.mdns=1
+connection.mdns=2
 
 # Disable LLMNR as it can conflict with mdns
 connection.llmnr=0

--- a/recipes/network/files/resolved.conf
+++ b/recipes/network/files/resolved.conf
@@ -1,0 +1,18 @@
+[Resolve]
+# Some examples of DNS servers which may be used for DNS= and FallbackDNS=:
+# Cloudflare: 1.1.1.1#cloudflare-dns.com 1.0.0.1#cloudflare-dns.com 2606:4700:4700::1111#cloudflare-dns.com 2606:4700:4700::1001#cloudflare-dns.com
+# Google:     8.8.8.8#dns.google 8.8.4.4#dns.google 2001:4860:4860::8888#dns.google 2001:4860:4860::8844#dns.google
+# Quad9:      9.9.9.9#dns.quad9.net 149.112.112.112#dns.quad9.net 2620:fe::fe#dns.quad9.net 2620:fe::9#dns.quad9.net
+#DNS=
+#FallbackDNS=
+#Domains=
+#DNSSEC=no
+#DNSOverTLS=no
+MulticastDNS=yes
+LLMNR=no
+#Cache=yes
+#CacheFromLocalhost=no
+#DNSStubListener=yes
+#DNSStubListenerExtra=
+#ReadEtcHosts=yes
+#ResolveUnicastSingleLabel=no

--- a/recipes/network/recipe.toml
+++ b/recipes/network/recipe.toml
@@ -1,0 +1,1 @@
+description = "Network configuration"

--- a/recipes/network/steps/00-packages
+++ b/recipes/network/steps/00-packages
@@ -1,0 +1,1 @@
+systemd-resolved

--- a/recipes/network/steps/01-install.sh
+++ b/recipes/network/steps/01-install.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+# NetworkManager default config
+install -D -m 644 "${RECIPE_DIR}/files/NetworkManager.conf" -T /etc/NetworkManager/NetworkManager.conf
+install -D -m 644 "${RECIPE_DIR}/files/globals.conf" -t /etc/NetworkManager/conf.d/
+
+install -D -m 644 "${RECIPE_DIR}/files/resolved.conf" -T /etc/systemd/resolved.conf
+
+systemctl enable systemd-resolved
+
+# Add mdns definitions
+mkdir -p /usr/lib/systemd/dnssd
+

--- a/recipes/network/steps/01-install.sh
+++ b/recipes/network/steps/01-install.sh
@@ -7,7 +7,14 @@ install -D -m 644 "${RECIPE_DIR}/files/globals.conf" -t /etc/NetworkManager/conf
 install -D -m 644 "${RECIPE_DIR}/files/resolved.conf" -T /etc/systemd/resolved.conf
 
 systemctl enable systemd-resolved
+# Try to disable avahi-daemon (but don't fail if not present)
+systemctl disable avahi-daemon ||:
+systemctl mask avahi-daemon ||:
 
 # Add mdns definitions
 mkdir -p /usr/lib/systemd/dnssd
 
+# systemd-resolved service definitions
+install -D -m 644 "${RECIPE_DIR}/files/dns-sd/tedge.dnssd" -t /usr/lib/systemd/dnssd/
+install -D -m 644 "${RECIPE_DIR}/files/dns-sd/ssh.dnssd" -t /usr/lib/systemd/dnssd/
+install -D -m 644 "${RECIPE_DIR}/files/dns-sd/sftp-ssh.dnssd" -t /usr/lib/systemd/dnssd/


### PR DESCRIPTION
Switch from avahi-daemon to using systemd-resolved to provide a DNS stub which enable mdns lookups for applications which are built with MUSL (which don't support the glibc NSS feature).

💥 Breaking Change
* The default mdns service description for mdns has change from `_thin-edge_mqtt._tcp` to `_tedge._tcp` as the former was incompatible with systemd-resolved