### PR TITLE
feat: add local PKI plugin to enable local TLS

### DIFF
--- a/recipes/essentials/recipe.toml
+++ b/recipes/essentials/recipe.toml
@@ -4,6 +4,7 @@ dependencies = [
     "persist-data",
     "persist-overlay",
     "tedge-bootstrap",
+    "tedge-local-pki",
     "tedge-firmware-update",
     "mosquitto",
 ]

--- a/recipes/tedge-local-pki/files/data.toml
+++ b/recipes/tedge-local-pki/files/data.toml
@@ -1,0 +1,2 @@
+[[persist]]
+directory = "/etc/step-ca"

--- a/recipes/tedge-local-pki/recipe.toml
+++ b/recipes/tedge-local-pki/recipe.toml
@@ -1,0 +1,2 @@
+description = "install thin-edge.io local pki community plugin"
+priority = 30_000

--- a/recipes/tedge-local-pki/recipe.toml
+++ b/recipes/tedge-local-pki/recipe.toml
@@ -1,2 +1,2 @@
 description = "install thin-edge.io local pki community plugin"
-priority = 30_000
+priority = 10_000

--- a/recipes/tedge-local-pki/steps/00-packages
+++ b/recipes/tedge-local-pki/steps/00-packages
@@ -1,0 +1,2 @@
+tedge-pki-smallstep-ca
+tedge-pki-smallstep-client

--- a/recipes/tedge-local-pki/steps/01-install.sh
+++ b/recipes/tedge-local-pki/steps/01-install.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+install -D -m 644 "${RECIPE_DIR}/files/etc-step-ca.toml" -t /etc/rugpi/state


### PR DESCRIPTION
Add tedge-pki-smallstep community plugin to make it easier to configure TLS for the local network and register child devices.