### PR TITLE
feat: update base raspi OS images to 2024-07-04

### DIFF
--- a/layers/raspios-stable.arm64.toml
+++ b/layers/raspios-stable.arm64.toml
@@ -1,2 +1,2 @@
 name = "Raspberry Pi OS (Bookworm)"
-url = "https://downloads.raspberrypi.com/raspios_lite_arm64/images/raspios_lite_arm64-2023-10-10/2023-10-10-raspios-bookworm-arm64-lite.img.xz"
+url = "https://downloads.raspberrypi.com/raspios_lite_arm64/images/raspios_lite_arm64-2024-07-04/2024-07-04-raspios-bookworm-arm64-lite.img.xz"

--- a/layers/raspios-stable.armhf.toml
+++ b/layers/raspios-stable.armhf.toml
@@ -1,2 +1,2 @@
 name = "Raspberry Pi OS (Bookworm)"
-url = "https://downloads.raspberrypi.com/raspios_lite_armhf/images/raspios_lite_armhf-2023-10-10/2023-10-10-raspios-bookworm-armhf-lite.img.xz"
+url = "https://downloads.raspberrypi.com/raspios_lite_armhf/images/raspios_lite_armhf-2024-07-04/2024-07-04-raspios-bookworm-armhf-lite.img.xz"

--- a/layers/raspios.arm64.toml
+++ b/layers/raspios.arm64.toml
@@ -1,2 +1,2 @@
 name = "Raspberry Pi OS (Bookworm)"
-url = "https://downloads.raspberrypi.com/raspios_lite_arm64/images/raspios_lite_arm64-2023-12-11/2023-12-11-raspios-bookworm-arm64-lite.img.xz"
+url = "https://downloads.raspberrypi.com/raspios_lite_arm64/images/raspios_lite_arm64-2024-07-04/2024-07-04-raspios-bookworm-arm64-lite.img.xz"

--- a/layers/raspios.armhf.toml
+++ b/layers/raspios.armhf.toml
@@ -1,2 +1,2 @@
 name = "Raspberry Pi OS (Bookworm)"
-url = "https://downloads.raspberrypi.com/raspios_lite_armhf/images/raspios_lite_armhf-2023-12-11/2023-12-11-raspios-bookworm-armhf-lite.img.xz"
+url = "https://downloads.raspberrypi.com/raspios_lite_armhf/images/raspios_lite_armhf-2024-07-04/2024-07-04-raspios-bookworm-armhf-lite.img.xz"


### PR DESCRIPTION
Update base Raspberry PI OS images from 2023-10-10 to 2024-07-04.

See release notes for the changes: [raspios_lite_arm64/release_notes.txt](https://downloads.raspberrypi.com/raspios_lite_arm64/release_notes.txt)