### PR TITLE
feat: add boot-options recipe to enable cgroups memory monitoring

### DIFF
--- a/recipes/boot-options/recipe.toml
+++ b/recipes/boot-options/recipe.toml
@@ -1,0 +1,2 @@
+description = "Sensible cmdline.txt options, e.g. enable cgroups monitoring"
+priority = 500_000  # Execute rather early to allow recipes to modify it

--- a/recipes/boot-options/steps/00-install.sh
+++ b/recipes/boot-options/steps/00-install.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+
+CMDLINE_FILE="/boot/firmware/cmdline.txt"
+
+echo "Modifying boot cmdline.txt to enable cgroup memory monitoring" >&2
+echo "File: $CMDLINE_FILE (before)" >&2
+cat "$CMDLINE_FILE" >&2
+
+CMDLINE_CONTENTS=$(cat "$CMDLINE_FILE")
+
+# remove duplicates, use xargs to trim leading and trailing spaces
+CMDLINE_CONTENTS=$(echo "$CMDLINE_CONTENTS" | sed 's/cgroup_memory=[a-z0-9A-Z,]*//g' | xargs)
+CMDLINE_CONTENTS=$(echo "$CMDLINE_CONTENTS" | sed 's/cgroup_enable=[a-z0-9A-Z,]*//g' | xargs)
+
+# append cgroup options
+printf "%s %s" "$CMDLINE_CONTENTS" "cgroup_memory=1 cgroup_enable=memory" > "$CMDLINE_FILE"
+
+echo "File: $CMDLINE_FILE (after)" >&2
+cat "$CMDLINE_FILE" >&2


### PR DESCRIPTION
Modify the cmdline.txt options to enable cgroup memory monitoring which is a pre-requisite for applications like k3s (see [k3s installation instructions](https://docs.k3s.io/installation/requirements?os=pi#operating-systems)).

Though generally enabling cgroup memory monitoring is helpful to see more detailed information include current memory usage when using `systemctl status <service>`.