### PR TITLE
fix: update the cmdline file path

### DIFF
--- a/recipes/boot-options/steps/00-install.sh
+++ b/recipes/boot-options/steps/00-install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-CMDLINE_FILE="/boot/firmware/cmdline.txt"
+CMDLINE_FILE="${RUGPI_BUNDLE_DIR}/roots/boot/cmdline.txt"
 
 echo "Modifying boot cmdline.txt to enable cgroup memory monitoring" >&2
 echo "File: $CMDLINE_FILE (before)" >&2


### PR DESCRIPTION
Fix the target path where the `cmdline.txt` file is located during the build stage.