### PR TITLE
feat: install next gen tedge-container-plugin

### DIFF
--- a/recipes/docker/files/suoders.tedge-container-plugin
+++ b/recipes/docker/files/suoders.tedge-container-plugin
@@ -1,0 +1,1 @@
+tedge  ALL = (ALL) NOPASSWD: /usr/bin/tedge-container, /usr/bin/docker

--- a/recipes/docker/files/tedge-networkcontainer.conf
+++ b/recipes/docker/files/tedge-networkcontainer.conf
@@ -1,0 +1,3 @@
+listener 1884 172.17.0.1
+allow_anonymous true
+require_certificate false

--- a/recipes/docker/steps/00-install.sh
+++ b/recipes/docker/steps/00-install.sh
@@ -30,3 +30,6 @@ install -D -m 644 "${RECIPE_DIR}/files/docker.toml" -t /etc/rugpi/state
 
 # Add mosquitto listener which allows other containers access to the thin-edge.io MQTT broker
 install -D -m 0644 "${RECIPE_DIR}/files/tedge-networkcontainer.conf" -t /etc/tedge/mosquitto-conf/
+
+# Add sudoers rules
+install -D -m 0644 "${RECIPE_DIR}/files/suoders.tedge-container-plugin" -T /etc/sudoers.d/tedge-container-plugin

--- a/recipes/docker/steps/00-install.sh
+++ b/recipes/docker/steps/00-install.sh
@@ -27,3 +27,6 @@ usermod -aG docker tedge
 
 # Copy Docker persist file
 install -D -m 644 "${RECIPE_DIR}/files/docker.toml" -t /etc/rugpi/state
+
+# Add mosquitto listener which allows other containers access to the thin-edge.io MQTT broker
+install -D -m 0644 "${RECIPE_DIR}/files/tedge-networkcontainer.conf" -t /etc/tedge/mosquitto-conf/

--- a/recipes/docker/steps/00-install.sh
+++ b/recipes/docker/steps/00-install.sh
@@ -21,7 +21,7 @@ apt-get install -y --no-install-recommends \
     containerd.io \
     docker-buildx-plugin \
     docker-compose-plugin \
-    tedge-container-plugin
+    tedge-container-plugin-ng
 
 usermod -aG docker tedge
 

--- a/recipes/mosquitto/steps/00-install.sh
+++ b/recipes/mosquitto/steps/00-install.sh
@@ -24,11 +24,17 @@ apt-get update
 # The same patch is also included in the yocto open-embedded recipe for mosquitto
 # See https://github.com/eclipse/mosquitto/issues/2878
 #
+# Slow down the restart rate of mosquitto so it does not trip the systemd restart rate limit
+# and stop mosquitto from starting altogether
+#
 mkdir -p /etc/systemd/system/mosquitto.service.d
 cat << EOT > /etc/systemd/system/mosquitto.service.d/override.conf
 [Unit]
 After=network-online.target
 Wants=network-online.target
+
+[Service]
+RestartSec = 5
 EOT
 chmod 644 /etc/systemd/system/mosquitto.service.d/override.conf
 


### PR DESCRIPTION
Update to the next gen tedge-container-plugin (`tedge-container-plugin-ng`) which has better container support and monitoring.

Add a dedicated mosquitto listener on port 1884 to allow access to the MQTT broker from the container network.