### PR TITLE
fix: enable mosquitto service by default

### DIFF
--- a/recipes/mosquitto/steps/00-install.sh
+++ b/recipes/mosquitto/steps/00-install.sh
@@ -18,17 +18,26 @@ esac
 echo 'deb [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian bookworm-backports main' > /etc/apt/sources.list.d/debian-bookworm-backports.list
 apt-get update
 
-#
-# Prevent problems where mosquitto service fails to start due to binding to a
-# non-existent IP address due to the network not being ready
-# The same patch is also included in the yocto open-embedded recipe for mosquitto
-# See https://github.com/eclipse/mosquitto/issues/2878
-#
-# Slow down the restart rate of mosquitto so it does not trip the systemd restart rate limit
-# and stop mosquitto from starting altogether
-#
-mkdir -p /etc/systemd/system/mosquitto.service.d
-cat << EOT > /etc/systemd/system/mosquitto.service.d/override.conf
+DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Options::=--force-confold -y --no-install-recommends install -t bookworm-backports \
+    mosquitto \
+    mosquitto-clients
+
+# Enable mosquitto by default (don't rely on the systemd )
+systemctl enable mosquitto
+
+
+patch_mosquitto_2011() {
+    #
+    # Prevent problems where mosquitto service fails to start due to binding to a
+    # non-existent IP address due to the network not being ready
+    # The same patch is also included in the yocto open-embedded recipe for mosquitto
+    # See https://github.com/eclipse/mosquitto/issues/2878
+    #
+    # Slow down the restart rate of mosquitto so it does not trip the systemd restart rate limit
+    # and stop mosquitto from starting altogether
+    #
+    mkdir -p /etc/systemd/system/mosquitto.service.d
+    cat << EOT > /etc/systemd/system/mosquitto.service.d/override.conf
 [Unit]
 After=network-online.target
 Wants=network-online.target
@@ -36,8 +45,31 @@ Wants=network-online.target
 [Service]
 RestartSec = 5
 EOT
-chmod 644 /etc/systemd/system/mosquitto.service.d/override.conf
+    chmod 644 /etc/systemd/system/mosquitto.service.d/override.conf
+}
 
-DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Options::=--force-confold -y --no-install-recommends install -t bookworm-backports \
-    mosquitto \
-    mosquitto-clients
+patch_mosquitto_2018() {
+    #
+    # Slow down the restart rate of mosquitto so it does not trip the systemd restart rate limit
+    # and stop mosquitto from starting altogether
+    #
+    mkdir -p /etc/systemd/system/mosquitto.service.d
+    cat << EOT > /etc/systemd/system/mosquitto.service.d/override.conf
+[Service]
+RestartSec = 5
+EOT
+    chmod 644 /etc/systemd/system/mosquitto.service.d/override.conf
+}
+
+MOSQUITTO_VERSION=$(dpkg -l mosquitto | grep '^.i' | awk -F' ' '{print $3}')
+echo "Mosquitto version: $MOSQUITTO_VERSION"
+case "$MOSQUITTO_VERSION" in
+    2.0.11* | 2.0.14* | 2.0.15*)
+        echo "Patching mosquitto service (network-online and restart rate limit)"
+        patch_mosquitto_2011
+        ;;
+    2.0.18* | 2.0.2* | 2.1*)
+        echo "Patching mosquitto service (restart rate limit)"
+        patch_mosquitto_2018
+        ;;
+esac


### PR DESCRIPTION
Enable the mosquitto by default in the image to ensure that firmware updates continue correctly after the partition swap.

Resolves https://github.com/thin-edge/tedge-rugpi-image/issues/87 and https://github.com/thin-edge/tedge-rugpi-core/issues/38