### PR TITLE
feat: support delta updates

### DIFF
--- a/recipes/defaults/recipe.toml
+++ b/recipes/defaults/recipe.toml
@@ -9,6 +9,8 @@ dependencies = [
     "set-wifi",
     "ssh",
 
+    "vnstat",
+
     # default cmdline options
     "boot-options",
 

--- a/recipes/tedge-firmware-update/files/firmware-version
+++ b/recipes/tedge-firmware-update/files/firmware-version
@@ -19,8 +19,20 @@ if [ ! -f "$ARTIFACT_FILE" ]; then
     exit 0
 fi
 
+SUDO=""
+if command -V sudo >/dev/null 2>&1; then
+    SUDO="sudo"
+fi
+
 NAME=$(jq -r '.name' "$ARTIFACT_FILE")
 VERSION=$(jq -r '.release.version // "0.0"' "$ARTIFACT_FILE")
 
 echo "name=\"$NAME\""
 echo "version=\"$VERSION\""
+
+# publish system image hash of the active partition to help selection of correct delta update
+ACTIVE_PARTITION=$(rugix-ctrl system info --json | jq -r .boot.activeGroup)
+SYSTEM_IMAGE_HASH=$($SUDO rugix-ctrl system info --json | jq -r '.slots."system-'"${ACTIVE_PARTITION}"'".hashes.sha512_256' ||:)
+if [ -n "$SYSTEM_IMAGE_HASH" ]; then
+    echo "system=\"$SYSTEM_IMAGE_HASH\""
+fi

--- a/recipes/tedge-firmware-update/files/rugix-system
+++ b/recipes/tedge-firmware-update/files/rugix-system
@@ -1,0 +1,74 @@
+#!/bin/sh
+##################################################
+# Rugix system information
+#
+# Example file contents:
+# ```
+# {
+#   "slots": {
+#     "boot-a": {
+#       "active": true,
+#       "hashes": {},
+#       "updatedAt": "2025-07-14T21:05:23.224099988Z"
+#     },
+#     "boot-b": {
+#       "active": false,
+#       "hashes": {},
+#       "updatedAt": "2025-07-14T20:15:01.459841658Z"
+#     },
+#     "system-a": {
+#       "active": true,
+#       "hashes": {
+#         "sha512_256": "sha512-256:f7b953f455c06b515333873de43ee5d69997d997432faf411755b7c4b525e4fa"
+#       },
+#       "size": 2406704640,
+#       "updatedAt": "2025-07-14T21:07:26.922661546Z"
+#     },
+#     "system-b": {
+#       "active": false,
+#       "hashes": {
+#         "sha512_256": "sha512-256:99f64878855be24d5e9a3a1aa64643cf08203c07aa48c79f34c4085eeefb165d"
+#       },
+#       "size": 2406704640,
+#       "updatedAt": "2025-07-14T20:16:59.002372104Z"
+#     }
+#   },
+#   "boot": {
+#     "bootFlow": "tryboot",
+#     "activeGroup": "a",
+#     "defaultGroup": "a",
+#     "groups": {
+#       "a": {},
+#       "b": {}
+#     }
+#   }
+# }
+# ```
+##################################################
+set -e
+ARTIFACT_FILE=/etc/rugix/system-build-info.json
+
+if [ ! -f "$ARTIFACT_FILE" ]; then
+    exit 0
+fi
+
+SUDO=""
+if command -V sudo >/dev/null 2>&1; then
+    SUDO="sudo"
+fi
+
+SYSTEM_INFO=$($SUDO rugix-ctrl system info --json 2>/dev/null)
+
+echo "defaultGroup=$(echo "$SYSTEM_INFO" | jq .boot.defaultGroup)"
+echo "activeGroup=$(echo "$SYSTEM_INFO" | jq .boot.activeGroup)"
+echo "bootFlow=$(echo "$SYSTEM_INFO" | jq .boot.bootFlow)"
+
+# use string due to wider c8y UI support for filtering on strings rather than a boolean
+echo "defaultActive=\"$(echo "$SYSTEM_INFO" | jq '.boot.activeGroup == .boot.defaultGroup')\""
+
+ACTIVE_PARTITION=$(echo "$SYSTEM_INFO" | jq -r .boot.activeGroup)
+ACTIVE_PARTITION_HASH=$(echo "$SYSTEM_INFO" | jq -r '.slots."system-'"${ACTIVE_PARTITION}"'".hashes.sha512_256 // ""' ||:)
+ACTIVE_UPDATED_AT=$(echo "$SYSTEM_INFO" | jq -r '.slots."system-'"${ACTIVE_PARTITION}"'".updatedAt // "-"' ||:)
+
+echo "hash=\"${ACTIVE_PARTITION_HASH}\""
+echo "updatedAt=\"${ACTIVE_UPDATED_AT}\""

--- a/recipes/tedge-firmware-update/files/rugix_workflow.sh
+++ b/recipes/tedge-firmware-update/files/rugix_workflow.sh
@@ -7,6 +7,9 @@ MANUAL_DOWNLOAD=0
 NETRC_FILE="${NETRC_FILE:-"/etc/tedge/.netrc"}"
 CHECK_META_INFO=0
 
+# Enable indexes whilst using dynamic or static delta updates as the first delta update
+DELTA_UPDATE_METHOD=${DELTA_UPDATE_METHOD:-casync}
+
 # Exit codes
 OK=0
 FAILED=1
@@ -233,6 +236,27 @@ download_file() {
 
 install() {
     url="$1"
+
+    # TODO: Is this required, or can the update provide additional information about what
+    # type of update it is and if the indexes are required or not
+    case "$DELTA_UPDATE_METHOD" in
+        casync)
+            # Note: It is possible that the need for this may be removed in future rugix versions
+            local_log "Preparing index for dynamic delta updates"
+            if [ "$BOOT_ACTIVE" = "a" ]; then
+                $SUDO rugix-ctrl slots create-index boot-a casync-64 sha512-256
+                $SUDO rugix-ctrl slots create-index system-a casync-64 sha512-256
+            else
+                $SUDO rugix-ctrl slots create-index boot-b casync-64 sha512-256
+                $SUDO rugix-ctrl slots create-index system-b casync-64 sha512-256
+            fi
+            ;;
+        xdelta)
+            # TODO: How to check if the slot can be used or not for delta updates
+            # See https://oss.silitics.com/rugix/docs/next/ctrl/delta-updates/#static-delta-updates
+            ;;
+    esac
+
     set +e
     case "$url" in
         http://*|https://*)

--- a/recipes/tedge-firmware-update/files/rugix_workflow.sh
+++ b/recipes/tedge-firmware-update/files/rugix_workflow.sh
@@ -287,14 +287,14 @@ install() {
     esac
 
     # Create mark file which is used by the restart state to reboot into the spare partition
-    touch "$REBOOT_SPARE_REQUEST"
+    touch "$REBOOT_SPARE_REQUEST" ||:
     exit "$EXIT_CODE"
 }
 
 restart() {
     # NOTE: This function should not be called in the script directly but rather via the system.toml
     if [ -f "$REBOOT_SPARE_REQUEST" ]; then
-        rm -f "$REBOOT_SPARE_REQUEST"
+        rm -f "$REBOOT_SPARE_REQUEST" ||:
 
         message=$(printf '{"text":"Rebooting into spare partition (%s -> %s)","partition":"%s"}' "$BOOT_ACTIVE" "$BOOT_SPARE" "$BOOT_ACTIVE")
         tedge mqtt pub -q 1 "te/device/main///e/reboot_spare" "$message" ||:

--- a/recipes/tedge-firmware-update/files/rugix_workflow.sh
+++ b/recipes/tedge-firmware-update/files/rugix_workflow.sh
@@ -361,6 +361,10 @@ commit() {
             log "rugix-ctrl returned code: $EXIT_CODE. Rolling back to previous partition"
             ;;
     esac
+
+    # update inventory scripts after the commit has been changed
+    $SUDO systemctl start tedge-inventory.service || local_log "Failed to run tedge-inventory.service"
+
     exit "$EXIT_CODE"
 }
 
@@ -376,6 +380,9 @@ rollback_successful() {
             fi
         fi
     done
+
+    # update inventory scripts after the commit has been changed
+    $SUDO systemctl start tedge-inventory.service || local_log "Failed to run tedge-inventory.service"
 
     log "Firmware update failed, but the rollback was successful. partition=$BOOT_ACTIVE, default=$BOOT_DEFAULT"
 }

--- a/recipes/tedge-firmware-update/files/rugix_workflow.sh
+++ b/recipes/tedge-firmware-update/files/rugix_workflow.sh
@@ -4,7 +4,7 @@ FIRMWARE_NAME=
 FIRMWARE_VERSION=
 FIRMWARE_URL=
 MANUAL_DOWNLOAD=0
-STREAM_DOWNLOAD=1
+STREAM_DOWNLOAD=auto
 NETRC_FILE="${NETRC_FILE:-"/etc/tedge/.netrc"}"
 CHECK_META_INFO=0
 
@@ -144,6 +144,7 @@ download() {
     #
     # Change url to a local url using the c8y proxy
     #
+    url_hosted_in_c8y=0
     case "$url" in
         https://*/inventory/binaries/*)
             # Cumulocity URL, use the c8y auth proxy service
@@ -151,6 +152,7 @@ download() {
             c8y_proxy_host=$(tedge config get c8y.proxy.client.host)
             c8y_proxy_port=$(tedge config get c8y.proxy.client.port)
             tedge_url="http://${c8y_proxy_host}:${c8y_proxy_port}/c8y/$partial_path"
+            url_hosted_in_c8y=1
             ;;
         http://*|https://*)
             # External URL, pass it untouched
@@ -163,6 +165,17 @@ download() {
             # Assume url is actually a file and just go to the next state
             update_state "$(printf '{"url":"%s"}\n' "$url")"
             return "$OK"
+            ;;
+    esac
+
+    case "$STREAM_DOWNLOAD" in
+        auto)
+            if [ "$url_hosted_in_c8y" = 1 ]; then
+                local_log "Letting rugix handling the artifact download (to enable both dynamic and static delta updates)"
+                STREAM_DOWNLOAD=0
+            else
+                STREAM_DOWNLOAD=1
+            fi
             ;;
     esac
 
@@ -242,14 +255,18 @@ install() {
     # type of update it is and if the indexes are required or not
     case "$DELTA_UPDATE_METHOD" in
         casync)
-            # Note: It is possible that the need for this may be removed in future rugix versions
-            local_log "Preparing index for dynamic delta updates"
-            if [ "$BOOT_ACTIVE" = "a" ]; then
-                $SUDO rugix-ctrl slots create-index boot-a casync-64 sha512-256
-                $SUDO rugix-ctrl slots create-index system-a casync-64 sha512-256
-            else
-                $SUDO rugix-ctrl slots create-index boot-b casync-64 sha512-256
-                $SUDO rugix-ctrl slots create-index system-b casync-64 sha512-256
+            # Note: dynamic updates aren't supported when streaming downloads as rugix needs
+            # do send the HTTP request to download the relevant portions of the binary
+            if [ "$STREAM_DOWNLOAD" = 0 ]; then
+                # Note: It is possible that the need for this may be removed in future rugix versions
+                local_log "Preparing index for dynamic delta updates"
+                if [ "$BOOT_ACTIVE" = "a" ]; then
+                    $SUDO rugix-ctrl slots create-index boot-a casync-64 sha512-256
+                    $SUDO rugix-ctrl slots create-index system-a casync-64 sha512-256
+                else
+                    $SUDO rugix-ctrl slots create-index boot-b casync-64 sha512-256
+                    $SUDO rugix-ctrl slots create-index system-b casync-64 sha512-256
+                fi
             fi
             ;;
         xdelta)

--- a/recipes/tedge-firmware-update/files/rugix_workflow.sh
+++ b/recipes/tedge-firmware-update/files/rugix_workflow.sh
@@ -4,6 +4,7 @@ FIRMWARE_NAME=
 FIRMWARE_VERSION=
 FIRMWARE_URL=
 MANUAL_DOWNLOAD=0
+STREAM_DOWNLOAD=1
 NETRC_FILE="${NETRC_FILE:-"/etc/tedge/.netrc"}"
 CHECK_META_INFO=0
 
@@ -261,7 +262,11 @@ install() {
     case "$url" in
         http://*|https://*)
             log "Downloading and streaming image to rugix"
-            download_file "$url" | $SUDO rugix-ctrl update install --reboot no -
+            if [ "$STREAM_DOWNLOAD" = 1 ]; then
+                download_file "$url" | $SUDO rugix-ctrl update install --reboot no -
+            else
+                $SUDO rugix-ctrl update install --reboot no "$url"
+            fi
             ;;
         *)
             # It is a file

--- a/recipes/tedge-firmware-update/files/tedge-firmware
+++ b/recipes/tedge-firmware-update/files/tedge-firmware
@@ -1,1 +1,1 @@
-tedge  ALL = (ALL) NOPASSWD: /usr/bin/rugix-ctrl, /usr/bin/rugix_workflow.sh
+tedge  ALL = (ALL) NOPASSWD: /usr/bin/rugix-ctrl, /usr/bin/rugix_workflow.sh, /usr/bin/systemctl start *

--- a/recipes/tedge-firmware-update/steps/00-packages.apk
+++ b/recipes/tedge-firmware-update/steps/00-packages.apk
@@ -1,3 +1,4 @@
 jq
 curl
 libarchive-tools
+xdelta3

--- a/recipes/tedge-firmware-update/steps/00-packages.apt
+++ b/recipes/tedge-firmware-update/steps/00-packages.apt
@@ -1,3 +1,4 @@
 jq
 curl
 libarchive-tools
+xdelta3

--- a/recipes/tedge-firmware-update/steps/01-install.sh
+++ b/recipes/tedge-firmware-update/steps/01-install.sh
@@ -5,6 +5,7 @@ install -D -m 644 "${RECIPE_DIR}/files/system.toml" -t /etc/tedge/
 install -D -m 644 "${RECIPE_DIR}/files/firmware_update.rugix.toml" -t /usr/share/tedge-workflows/
 install -D -m 755 "${RECIPE_DIR}/files/rugix_workflow.sh" -t /usr/bin/
 install -D -m 755 "${RECIPE_DIR}/files/firmware-version" /usr/share/tedge-inventory/scripts.d/80_firmware
+install -D -m 755 "${RECIPE_DIR}/files/rugix-system" /usr/share/tedge-inventory/scripts.d/85_rugix_System
 
 # auto rollback service incase if new agent is corrupt (only rely on tooling which is definitely there)
 install -D -m 755 "${RECIPE_DIR}/files/firmware-auto-rollback" /usr/bin/firmware-auto-rollback

--- a/recipes/thin-edge.io/steps/01-install.sh
+++ b/recipes/thin-edge.io/steps/01-install.sh
@@ -14,6 +14,23 @@ fi
 
 RECIPE_PARAM_CHANNEL="${RECIPE_PARAM_CHANNEL:-release}"
 
+# Check if the desired tedge group id is already being used by another group
+# if so, reassign it.
+# On Debian trixie, the 'render' group is already to gid 992 causing the conflict
+EXISTING_GROUP_GID=$(getent group 992 ||:)
+if [ -n "$EXISTING_GROUP_GID" ]; then
+    case "$EXISTING_GROUP_GID" in
+        tedge:x:992:)
+            # nothing to do
+            ;;
+        *)
+            group_name=$(echo "$EXISTING_GROUP_GID" | cut -d: -f1)
+            echo "Reassigning ${group_name} gid to 892 (from ${EXISTING_GROUP_GID})" >&2
+            groupmod -g 892 "$group_name"
+            ;;
+    esac
+fi
+
 # Used fixed uid/gid to avoid permission issues across A/B updates
 groupadd --system --gid 992 tedge || groupmod -g 992 tedge
 useradd --system --no-create-home --shell "/bin/false" --uid 999 --gid 992 tedge || usermod -u 999 tedge

--- a/recipes/vnstat/files/vnstat-database.toml
+++ b/recipes/vnstat/files/vnstat-database.toml
@@ -1,0 +1,2 @@
+[[persist]]
+directory = "/var/lib/vnstat"

--- a/recipes/vnstat/recipe.toml
+++ b/recipes/vnstat/recipe.toml
@@ -1,0 +1,2 @@
+name = "vnstat"
+description = "Install vnstat and configure network usage monitoring for IoT devices"

--- a/recipes/vnstat/steps/00-packages.apk
+++ b/recipes/vnstat/steps/00-packages.apk
@@ -1,0 +1,3 @@
+vnstat
+vnstat-openrc
+vnstati

--- a/recipes/vnstat/steps/00-packages.apt
+++ b/recipes/vnstat/steps/00-packages.apt
@@ -1,0 +1,2 @@
+vnstat
+vnstati

--- a/recipes/vnstat/steps/01-install.sh
+++ b/recipes/vnstat/steps/01-install.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+# Persist database
+install -D -m 644 "${RECIPE_DIR}/files/vnstat-database.toml" -t /etc/rugix/state
+
+groupmod -g 116 vnstat
+usermod -u 116 vnstat


### PR DESCRIPTION
Initial support for the [Rugix delta update support](https://oss.silitics.com/rugix/docs/ctrl/delta-updates) (for both dynamic and static updates). This leads to a massive saving when downloading an update, where a 700MB can be reduced to about 35MB (depending on the amount of changes).

The static delta updates are still lacking a server side feature which makes it easier for users to select the correct static delta update which matches the currently installed version. This part of the feature is still in development as it requires more a platform-side service (to both generate the deltas and help with delta update selection).

**Features**

* Support installing Rugix delta static update (users must send the device the delta rugixb file in order for it to be applied)
* Add new `rugix_System` twin property (fragment) to track the current partition and system hash (so that users can find which delta update can be applied to the image more easily)
* Add `vnstat` recipe to track network bandwidth stats over time (only stored on the device and not published anywhere yet)

**Caveats**

Below are the list of caveats to the delta updates (though some of these may be lifted in the future)

* Static delta updates can only be applied if at least 1 prior update has occurred (e.g. 1 update after the initial flashing of the image). Reason being is that the initial system hash of the slot is required to know the base name, and this hash is not present when flashing the initial base image to the SD Card.
* Static delta updates are not automatically selected by the device, instead the user needs to select the correct static binary which matches the currently installed system image. However there is no harm in sending the wrong static delta update, it will just fail to update.
* Dynamic delta updated only work if the artifact is hosted in Cumulocity (as the thin-edge.io provides a local c8y proxy service which handles the authentication, and currently authenticated endpoints are handled by curl (via netrc) instead of using rugix-ctrl which prevents the dynamic updates feature from working)
