### PR TITLE
fix(vnstat): resolved inflated network statistics caused by A/B partition swap

### DIFF
--- a/recipes/vnstat/files/override.conf
+++ b/recipes/vnstat/files/override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/sbin/vnstatd -n --sync

--- a/recipes/vnstat/steps/01-install.sh
+++ b/recipes/vnstat/steps/01-install.sh
@@ -6,3 +6,7 @@ install -D -m 644 "${RECIPE_DIR}/files/vnstat-database.toml" -t /etc/rugix/state
 
 groupmod -g 116 vnstat
 usermod -u 116 vnstat
+
+# modify vnstatd service to use --sync which prevents the interface statistics
+# being inflated when switching A/B partitions during a firmware update
+install -D -m 644 "${RECIPE_DIR}/files/override.conf" -t /etc/systemd/system/vnstat.service.d/


### PR DESCRIPTION
Modify the vnstatd service to include the `--sync` argument which ensure the interface counters are synced on the first update. This prevents [an issue](https://github.com/thin-edge/thin-edge.io/issues/3754) where the network statitics are inflated due to the counters being reset during a firmware update (after a partition swap).