### PR TITLE
feat: set journald log limits

### DIFF
--- a/recipes/defaults/recipe.toml
+++ b/recipes/defaults/recipe.toml
@@ -16,4 +16,6 @@ dependencies = [
 
     # enable mdns (for statically compiled musl binaries)
     "systemd-resolved",
+
+    "systemd-journald-defaults",
 ]

--- a/recipes/docker/files/daemon.json
+++ b/recipes/docker/files/daemon.json
@@ -1,0 +1,3 @@
+{
+    "log-driver": "journald"
+}

--- a/recipes/docker/steps/00-install.sh
+++ b/recipes/docker/steps/00-install.sh
@@ -46,6 +46,9 @@ apt-get install -y --no-install-recommends \
 
 usermod -aG docker tedge
 
+# default daemon settings
+install -D -m 644 "${RECIPE_DIR}/files/daemon.json" -t /etc/docker/
+
 # Copy Docker persist file
 install -D -m 644 "${RECIPE_DIR}/files/docker.toml" -t /etc/rugix/state
 

--- a/recipes/systemd-journald-defaults/files/00-storage-limits.conf
+++ b/recipes/systemd-journald-defaults/files/00-storage-limits.conf
@@ -1,0 +1,13 @@
+# journald storage limits configuration
+# See systemd.journald.conf(5) for details
+[Journal]
+# Maximum disk space used by journal logs (e.g., 100M, 1G)
+SystemMaxUse=200M
+# Maximum size of individual journal files
+SystemMaxFileSize=50M
+# Retain journal logs for a maximum of 2 weeks
+MaxRetentionSec=2week
+# Remove archived journal files when disk space is low
+SystemKeepFree=100M
+# Maximum disk space for user journals (if applicable)
+RuntimeMaxUse=50M

--- a/recipes/systemd-journald-defaults/recipe.toml
+++ b/recipes/systemd-journald-defaults/recipe.toml
@@ -1,0 +1,3 @@
+#:schema https://raw.githubusercontent.com/silitics/rugix/refs/tags/v0.8.0/schemas/rugix-bakery-recipe.schema.json
+description = "default systemd journald settings"
+dependencies = []

--- a/recipes/systemd-journald-defaults/steps/00-install.sh
+++ b/recipes/systemd-journald-defaults/steps/00-install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+# set sensible storage limits
+install -D -m 644 "${RECIPE_DIR}/files/00-storage-limits.conf" -t /etc/systemd/journald.conf.d/


### PR DESCRIPTION
Configure storage limits for systemd journald logging to ensure that that disk space doesn't get used up with the logs.

The docker logs are now also configured to use the journald for logging, so that the container logs also benefit from the log rotation / limits configured in journald.