### PR TITLE
fix: ensure persistence for containerd in docker configuration

### DIFF
--- a/recipes/docker/files/docker.toml
+++ b/recipes/docker/files/docker.toml
@@ -3,3 +3,6 @@ directory = "/etc/docker"
 
 [[persist]]
 directory = "/var/lib/docker"
+
+[[persist]]
+directory = "/var/lib/containerd"


### PR DESCRIPTION
containerd is now the default store for docker and needs to be persisted, and not doing so also prevents pulling images due to bad interactions with the rugix state management due to the usage of overlays